### PR TITLE
Add interactive course table with sorting, filtering, and column management

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,10 +45,7 @@ jobs:
         uses: actions/configure-pages@v5
 
       - name: Fetch data
-        run: |
-          pnpx tsx fetch-data.ts
-          pnpx tsx transform.ts
-          pnpx tsx build-db.ts
+        run: pnpm run data
       - name: Build page
         env:
           NUXT_PUBLIC_CI_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ as a plain, snappy, static website.
 
 - **Browse by semester → study → curriculum → course.** Pick a semester, pick your
   study programme, and walk the curriculum tree down to the individual courses.
+- **Configurable course table.** Every column can be sorted, filtered and hidden;
+  besides the dates of a course there are optional columns for SWS, the recommended
+  semester, the subject type and the examination method. The setup is kept in the URL,
+  so a configured view can simply be shared, and is remembered for the next visit.
 - **Advanced SQL query page** (`/query`, ⚠️ _work in progress_). The same data is
   also shipped as a single SQLite file. The page loads the official
   [SQLite WASM][sqlite-wasm] build entirely in your browser and lets you run
@@ -32,7 +36,7 @@ generation step:
 | Stage | Script | Output |
 | --- | --- | --- |
 | Fetch | [`fetch-data.ts`](./fetch-data.ts) | Raw course JSON in `~/.cache/campusoffline/<semesterId>/course<id>.json` |
-| Transform | [`transform.ts`](./transform.ts) | Per-semester `studiesTree.json` powering the browse pages |
+| Transform | [`transform.ts`](./transform.ts) | Per-semester `studiesTree.json` and `courses.json` powering the browse pages |
 | Build DB | [`build-db.ts`](./build-db.ts) | `public/db/courses.sqlite3` powering the query page |
 | Generate | `nuxt generate` | Static site in `.output/public` |
 
@@ -48,7 +52,13 @@ during prerendering, so the deployed site is 100% static.
 - `curricula` — one row per study programme / curriculum version
 - `curriculum_nodes` — the curriculum tree as an adjacency list (`parent_element_id`)
 - `course_placements` — fact table linking each course to where it sits in a study
+- `course_groups` — the (registration) groups a course is split into
+- `course_appointments` — recurring slots per course: the individual dates of a term
+  collapsed into one row per weekday/time/room, cancelled dates excluded
 - `meta` — `fetched_at` / `generated_at` timestamps
+
+Course dates come from RWTHonline's course group resource. Exam courses
+(_Fach-/Modulprüfung_) are not part of it, so those courses carry no appointments.
 
 The query page downloads this file once and loads it into an in-memory database via
 [`sqlite3_deserialize`][deserialize]. This in-memory path needs no cross-origin

--- a/README.md
+++ b/README.md
@@ -68,8 +68,9 @@ isolation headers (COOP/COEP), which GitHub Pages cannot set.
 
 ### Requirements
 
-- **Node.js ≥ 22** — `build-db.ts` uses the built-in [`node:sqlite`][node-sqlite]
-  module, which is unavailable on older versions.
+- **Node.js ≥ 22.18** — the data scripts are TypeScript and are run by Node itself
+  via [type stripping][type-stripping], which is enabled by default from that version
+  on. `build-db.ts` additionally uses the built-in [`node:sqlite`][node-sqlite] module.
 - **[pnpm][pnpm]**
 
 ### Setup
@@ -84,9 +85,15 @@ The browse pages and the query database are built from a local cache. Populate i
 then derive the artefacts (this talks to RWTHonline, so it needs network access):
 
 ```bash
-pnpx tsx fetch-data.ts     # scrape RWTHonline into ~/.cache/campusoffline/
-pnpx tsx transform.ts      # build the per-semester studiesTree.json
-pnpx tsx build-db.ts       # build public/db/courses.sqlite3
+pnpm run data              # all three stages below, in order
+```
+
+The stages can also be run individually:
+
+```bash
+pnpm run data:fetch        # scrape RWTHonline into ~/.cache/campusoffline/
+pnpm run data:transform    # build the per-semester studiesTree.json and courses.json
+pnpm run data:build-db     # build public/db/courses.sqlite3
 ```
 
 ### Run
@@ -117,4 +124,5 @@ Contributions and feedback are welcome — please open an issue or pull request.
 [pnpm]: https://pnpm.io/
 [sqlite-wasm]: https://sqlite.org/wasm
 [node-sqlite]: https://nodejs.org/api/sqlite.html
+[type-stripping]: https://nodejs.org/api/typescript.html#type-stripping
 [deserialize]: https://www.sqlite.org/c3ref/deserialize.html

--- a/appointments.ts
+++ b/appointments.ts
@@ -1,0 +1,91 @@
+import type { CourseGroupDto } from "./course-groups-resp";
+
+export type AppointmentSummary = {
+  /** Abbreviated weekday as delivered by RWTHonline, e.g. "Mo.". */
+  weekday: string;
+  /** Weekday id (Monday = 1), used for sorting. */
+  weekdaySort: number;
+  /** Start time as "HH:MM". */
+  from: string;
+  /** End time as "HH:MM". */
+  to: string;
+  /** Room including its building code, e.g. "TEMP1 (1515|001)". */
+  room: string | null;
+  /** How often this slot actually takes place. */
+  count: number;
+  /** Group name, only set for courses split into multiple groups. */
+  group?: string;
+};
+
+/**
+ * Collapse the individual appointments of a course
+ * into the recurring slots one would put into a timetable.
+ * Cancelled dates are left out entirely,
+ * so the count reflects how often a slot really takes place.
+ */
+export function summarizeAppointments(
+  groups: readonly CourseGroupDto[]
+): AppointmentSummary[] {
+  const multipleGroups = groups.length > 1;
+  const slots = new Map<string, AppointmentSummary>();
+
+  for (const group of groups) {
+    for (const appointment of group.appointmentDtos ?? []) {
+      if (appointment.appointmentStatusType !== "CONFIRMED") {
+        continue;
+      }
+      const from = appointment.timestampFrom.value.slice(11, 16);
+      const to = appointment.timestampTo.value.slice(11, 16);
+      const room = appointment.resourceName ?? null;
+      const groupName = multipleGroups ? group.name : undefined;
+      const key = JSON.stringify([
+        groupName,
+        appointment.weekday.id,
+        from,
+        to,
+        room,
+      ]);
+
+      const slot = slots.get(key);
+      if (slot) {
+        slot.count++;
+      } else {
+        slots.set(key, {
+          weekday: appointment.weekday.key,
+          weekdaySort: appointment.weekday.id,
+          from,
+          to,
+          room,
+          count: 1,
+          ...(groupName ? { group: groupName } : {}),
+        });
+      }
+    }
+  }
+
+  return [...slots.values()].sort(
+    (a, b) =>
+      (a.group ?? "").localeCompare(b.group ?? "") ||
+      a.weekdaySort - b.weekdaySort ||
+      a.from.localeCompare(b.from) ||
+      (a.room ?? "").localeCompare(b.room ?? "")
+  );
+}
+
+/**
+ * Render a slot the way it is shown in the course table.
+ * The occurrences are always spelled out:
+ * a slot which only takes place once still shows up with a weekday
+ * and would otherwise look like a weekly one.
+ */
+export function formatAppointment(appointment: AppointmentSummary): string {
+  const weekday = appointment.weekday.replace(/\.$/, "");
+  return [
+    appointment.group,
+    `${weekday} ${appointment.from}-${appointment.to}`,
+    appointment.room,
+    `(×${appointment.count})`,
+  ]
+    .filter(Boolean)
+    .join(" ");
+}

--- a/build-db.ts
+++ b/build-db.ts
@@ -5,6 +5,7 @@ import { DatabaseSync } from "node:sqlite";
 import { glob } from "glob";
 import type { SerializedCourse } from "./serialized-course";
 import type { Semester } from "./semesters-resp";
+import { summarizeAppointments } from "./appointments";
 
 const CACHE_DIR = path.join(homedir(), ".cache/campusoffline");
 const OUT_DIR = path.resolve("public/db");
@@ -33,6 +34,7 @@ CREATE TABLE courses (
   ects_credits           REAL,
   course_type_key        TEXT,
   course_type_name       TEXT,
+  sws                    TEXT,
   exam_method            TEXT,
   registration_available INTEGER,
   elearning_active       INTEGER
@@ -67,6 +69,27 @@ CREATE TABLE course_placements (
   semester_recommendation TEXT
 );
 
+CREATE TABLE course_groups (
+  id             INTEGER PRIMARY KEY,
+  course_id      INTEGER REFERENCES courses(id),
+  name           TEXT,
+  standard_group INTEGER
+);
+
+-- Recurring slots of a course:
+-- the individual dates of a term collapsed into one row per weekday/time/room,
+-- cancelled dates excluded.
+CREATE TABLE course_appointments (
+  course_id    INTEGER REFERENCES courses(id),
+  group_name   TEXT,
+  weekday      TEXT,
+  weekday_sort INTEGER,
+  starts_at    TEXT,
+  ends_at      TEXT,
+  room         TEXT,
+  occurrences  INTEGER
+);
+
 CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT);
 `;
 
@@ -76,6 +99,9 @@ CREATE INDEX idx_courses_title       ON courses(title);
 CREATE INDEX idx_placements_course   ON course_placements(course_id);
 CREATE INDEX idx_placements_curric   ON course_placements(curriculum_version_id, leaf_element_id);
 CREATE INDEX idx_nodes_parent        ON curriculum_nodes(curriculum_version_id, parent_element_id);
+CREATE INDEX idx_groups_course       ON course_groups(course_id);
+CREATE INDEX idx_appointments_course ON course_appointments(course_id);
+CREATE INDEX idx_appointments_slot   ON course_appointments(weekday_sort, starts_at);
 `;
 
 async function main() {
@@ -98,9 +124,10 @@ async function main() {
   const insertCourse = db.prepare(
     `INSERT OR REPLACE INTO courses
        (id, semester_id, course_number, title, ects_credits, course_type_key,
-        course_type_name, exam_method, registration_available, elearning_active)
+        course_type_name, sws, exam_method, registration_available,
+        elearning_active)
      VALUES (@id, @semester_id, @course_number, @title, @ects_credits,
-        @course_type_key, @course_type_name, @exam_method,
+        @course_type_key, @course_type_name, @sws, @exam_method,
         @registration_available, @elearning_active)`
   );
   const insertCurriculum = db.prepare(
@@ -115,6 +142,18 @@ async function main() {
        (curriculum_version_id, element_id, name, icon_name, parent_element_id)
      VALUES (@curriculum_version_id, @element_id, @name, @icon_name,
         @parent_element_id)`
+  );
+  const insertGroup = db.prepare(
+    `INSERT OR IGNORE INTO course_groups
+       (id, course_id, name, standard_group)
+     VALUES (@id, @course_id, @name, @standard_group)`
+  );
+  const insertAppointment = db.prepare(
+    `INSERT INTO course_appointments
+       (course_id, group_name, weekday, weekday_sort, starts_at, ends_at, room,
+        occurrences)
+     VALUES (@course_id, @group_name, @weekday, @weekday_sort, @starts_at,
+        @ends_at, @room, @occurrences)`
   );
   const insertPlacement = db.prepare(
     `INSERT INTO course_placements
@@ -137,13 +176,14 @@ async function main() {
 
   let courseCount = 0;
   let placementCount = 0;
+  let appointmentCount = 0;
 
   db.exec("BEGIN");
   try {
     for (const { id } of cache.semesters) {
       const dir = path.join(CACHE_DIR, id.toString());
       const courseFiles = (
-        await glob("course*.json", { withFileTypes: true, cwd: dir })
+        await glob("course[0-9]*.json", { withFileTypes: true, cwd: dir })
       ).filter((f) => f.isFile());
 
       for (const file of courseFiles) {
@@ -160,11 +200,36 @@ async function main() {
           ects_credits: c.ectsCredits ?? null,
           course_type_key: c.courseTypeDto?.key ?? null,
           course_type_name: c.courseTypeDto?.courseTypeName?.value ?? null,
+          // SST is the course norm config carrying the SWS ("Semesterwochenstunden")
+          sws: c.courseNormConfigs?.find((n) => n.key === "SST")?.value ?? null,
           exam_method: c.examinationMethodName?.value ?? null,
           registration_available: c.registrationAvailable ? 1 : 0,
           elearning_active: c.eLearningActive ? 1 : 0,
         });
         courseCount++;
+
+        for (const group of course.courseGroups ?? []) {
+          insertGroup.run({
+            id: group.id,
+            course_id: c.id,
+            name: group.name,
+            // RWTHonline spells booleans J/N (Ja/Nein)
+            standard_group: group.standardgroupFlag === "J" ? 1 : 0,
+          });
+        }
+        for (const slot of summarizeAppointments(course.courseGroups ?? [])) {
+          insertAppointment.run({
+            course_id: c.id,
+            group_name: slot.group ?? null,
+            weekday: slot.weekday,
+            weekday_sort: slot.weekdaySort,
+            starts_at: slot.from,
+            ends_at: slot.to,
+            room: slot.room,
+            occurrences: slot.count,
+          });
+          appointmentCount++;
+        }
 
         for (const { coCurriculumPositionDto: pos } of course.curriculumPositions) {
           const study = pos.studyNameInfoDto;
@@ -227,6 +292,7 @@ async function main() {
   console.log("#Semesters:", cache.semesters.length);
   console.log("#Courses:", courseCount);
   console.log("#Placements:", placementCount);
+  console.log("#Appointments:", appointmentCount);
   console.log("DB written:", OUT_FILE, `(${(size / 1e6).toFixed(2)} MB)`);
 }
 

--- a/build-db.ts
+++ b/build-db.ts
@@ -5,7 +5,7 @@ import { DatabaseSync } from "node:sqlite";
 import { glob } from "glob";
 import type { SerializedCourse } from "./serialized-course";
 import type { Semester } from "./semesters-resp";
-import { summarizeAppointments } from "./appointments";
+import { summarizeAppointments } from "./appointments.ts";
 
 const CACHE_DIR = path.join(homedir(), ".cache/campusoffline");
 const OUT_DIR = path.resolve("public/db");

--- a/components/CourseTable.vue
+++ b/components/CourseTable.vue
@@ -1,0 +1,448 @@
+<template>
+  <details class="columns">
+    <summary>
+      Columns ({{ visibleColumns.length }}/{{ columns.length }})
+    </summary>
+    <label v-for="column in columns" :key="column.key">
+      <input
+        type="checkbox"
+        :checked="visible.includes(column.key)"
+        @change="toggleColumn(column.key)"
+      />
+      {{ column.label }}
+    </label>
+    <button type="button" @click="reset">Reset</button>
+  </details>
+
+  <p class="summary">
+    {{ sortedRows.length }} of {{ rows.length }} course{{
+      rows.length === 1 ? "" : "s"
+    }}
+  </p>
+
+  <table>
+    <thead>
+      <tr>
+        <th
+          v-for="column in visibleColumns"
+          :key="column.key"
+          :aria-sort="ariaSort(column.key)"
+        >
+          <button type="button" class="sort" @click="toggleSort(column.key)">
+            {{ column.label }}
+            <span class="indicator">{{ sortIndicator(column.key) }}</span>
+          </button>
+        </th>
+      </tr>
+      <tr class="filters">
+        <td v-for="column in visibleColumns" :key="column.key">
+          <select
+            v-if="column.filter === 'select'"
+            :value="filters[column.key] ?? ''"
+            @change="
+              setFilter(column.key, ($event.target as HTMLSelectElement).value)
+            "
+          >
+            <option value="">(all)</option>
+            <option v-for="option in options(column)" :key="option">
+              {{ option }}
+            </option>
+          </select>
+          <input
+            v-else
+            type="search"
+            :value="filters[column.key] ?? ''"
+            :placeholder="`Filter ${column.label}`"
+            @input="
+              setFilter(column.key, ($event.target as HTMLInputElement).value)
+            "
+          />
+        </td>
+      </tr>
+    </thead>
+
+    <!--
+      One tbody per run of rows sharing a module keeps the alternating background
+      of the module groups and allows the rowspan below.
+
+      The rowspan shenanigans are to fix one of:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1000435
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=217769
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=244135
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=332740
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=332977
+    -->
+    <tbody v-for="(group, groupIdx) in groupedRows" :key="groupIdx">
+      <tr v-for="(row, rowIdx) in group.rows" :key="row.key">
+        <template v-for="column in visibleColumns" :key="column.key">
+          <template v-if="column.key === 'module'">
+            <td v-if="rowIdx === 0" :rowspan="group.rows.length">
+              {{ row.module }}
+            </td>
+          </template>
+          <td v-else-if="column.key === 'type'">
+            (<i :class="`icon_${row.iconName}`" />)
+            {{ row.courseType }}
+          </td>
+          <td v-else-if="column.key === 'dates'" class="dates">
+            <template v-for="(slot, idx) in row.appointments" :key="idx">
+              <br v-if="idx > 0" />{{ formatAppointment(slot) }}
+            </template>
+          </td>
+          <td v-else-if="column.key === 'id'">
+            <a
+              :href="`https://online.rwth-aachen.de/RWTHonline/ee/ui/ca2/app/desktop/#/slc.tm.cp/student/courses/${row.courseId}`"
+            >
+              {{ row.courseId }}
+            </a>
+          </td>
+          <td v-else :class="{ numeric: column.numeric }">
+            {{ column.text(row) }}
+          </td>
+        </template>
+      </tr>
+    </tbody>
+  </table>
+</template>
+
+<script setup lang="ts">
+import { formatAppointment } from "~/appointments";
+import type { CourseRow } from "~/course-row";
+
+type Column = {
+  key: string;
+  label: string;
+  /** Whether the column is shown before the user configured anything. */
+  default: boolean;
+  filter: "text" | "select";
+  numeric?: boolean;
+  /** Textual representation, used for display, filtering and sorting. */
+  text: (row: CourseRow) => string;
+  /** Overrides `text` for sorting where the displayed order is not useful. */
+  sortKey?: (row: CourseRow) => number | string;
+};
+
+const STORAGE_KEY = "campusoffline:courseTable";
+
+const props = defineProps<{ rows: CourseRow[] }>();
+
+const columns: Column[] = [
+  {
+    key: "module",
+    label: "Module",
+    default: true,
+    filter: "text",
+    text: (row) => row.module,
+  },
+  {
+    key: "type",
+    label: "Course Type",
+    default: true,
+    filter: "select",
+    text: (row) => row.courseType,
+  },
+  {
+    key: "title",
+    label: "Name",
+    default: true,
+    filter: "text",
+    text: (row) => row.title,
+  },
+  {
+    key: "credits",
+    label: "Credits",
+    default: true,
+    filter: "text",
+    numeric: true,
+    text: (row) => row.credits?.toString() ?? "",
+    sortKey: (row) => row.credits ?? Number.NEGATIVE_INFINITY,
+  },
+  {
+    key: "sws",
+    label: "SWS",
+    default: false,
+    filter: "text",
+    numeric: true,
+    text: (row) => row.sws ?? "",
+    sortKey: (row) => Number(row.sws) || Number.NEGATIVE_INFINITY,
+  },
+  {
+    key: "semester",
+    label: "Rec. Semester",
+    default: false,
+    filter: "select",
+    text: (row) => row.semesterRecommendation ?? "",
+  },
+  {
+    key: "subject",
+    label: "Subject Type",
+    default: false,
+    filter: "select",
+    text: (row) => row.subjectType ?? "",
+  },
+  {
+    key: "exam",
+    label: "Examination",
+    default: false,
+    filter: "text",
+    text: (row) => row.examMethod ?? "",
+  },
+  {
+    key: "dates",
+    label: "Dates",
+    default: true,
+    filter: "text",
+    text: (row) => row.appointments.map(formatAppointment).join("\n"),
+    sortKey: (row) =>
+      row.appointments.length
+        ? row.appointments[0].weekdaySort * 10000 +
+          Number(row.appointments[0].from.replace(":", ""))
+        : Number.POSITIVE_INFINITY,
+  },
+  {
+    key: "id",
+    label: "ID",
+    default: true,
+    filter: "text",
+    numeric: true,
+    text: (row) => row.courseId,
+    sortKey: (row) => Number(row.courseId),
+  },
+];
+
+const defaultColumns = columns.filter((c) => c.default).map((c) => c.key);
+const byKey = new Map(columns.map((column) => [column.key, column]));
+
+const visible = ref<string[]>([...defaultColumns]);
+const sortBy = ref<string | null>(null);
+const sortDesc = ref(false);
+const filters = ref<Record<string, string>>({});
+
+const visibleColumns = computed(() =>
+  columns.filter((column) => visible.value.includes(column.key))
+);
+
+const filteredRows = computed(() =>
+  props.rows.filter((row) =>
+    Object.entries(filters.value).every(([key, needle]) => {
+      const column = byKey.get(key);
+      if (!column || !needle) {
+        return true;
+      }
+      const value = column.text(row);
+      return column.filter === "select"
+        ? value === needle
+        : value.toLowerCase().includes(needle.toLowerCase());
+    })
+  )
+);
+
+const sortedRows = computed(() => {
+  const column = sortBy.value ? byKey.get(sortBy.value) : undefined;
+  if (!column) {
+    return filteredRows.value;
+  }
+  const key = column.sortKey ?? column.text;
+  const direction = sortDesc.value ? -1 : 1;
+  return filteredRows.value.toSorted((a, b) => {
+    const [valA, valB] = [key(a), key(b)];
+    const order =
+      typeof valA === "number" && typeof valB === "number"
+        ? valA - valB
+        : String(valA).localeCompare(String(valB));
+    return order * direction;
+  });
+});
+
+const groupedRows = computed(() => {
+  const groups: { module: string; rows: CourseRow[] }[] = [];
+  for (const row of sortedRows.value) {
+    const last = groups.at(-1);
+    if (last && last.module === row.module) {
+      last.rows.push(row);
+    } else {
+      groups.push({ module: row.module, rows: [row] });
+    }
+  }
+  return groups;
+});
+
+function options(column: Column) {
+  return [...new Set(props.rows.map((row) => column.text(row)))]
+    .filter(Boolean)
+    .sort((a, b) => a.localeCompare(b));
+}
+
+function toggleColumn(key: string) {
+  visible.value = visible.value.includes(key)
+    ? visible.value.filter((k) => k !== key)
+    : columns
+        .map((c) => c.key)
+        .filter((k) => visible.value.includes(k) || k === key);
+}
+
+function toggleSort(key: string) {
+  if (sortBy.value !== key) {
+    sortBy.value = key;
+    sortDesc.value = false;
+  } else if (!sortDesc.value) {
+    sortDesc.value = true;
+  } else {
+    sortBy.value = null;
+    sortDesc.value = false;
+  }
+}
+
+function setFilter(key: string, value: string) {
+  const { [key]: _dropped, ...rest } = filters.value;
+  filters.value = value ? { ...rest, [key]: value } : rest;
+}
+
+function reset() {
+  visible.value = [...defaultColumns];
+  sortBy.value = null;
+  sortDesc.value = false;
+  filters.value = {};
+}
+
+function sortIndicator(key: string) {
+  return sortBy.value !== key ? "" : sortDesc.value ? "▼" : "▲";
+}
+
+function ariaSort(key: string) {
+  return sortBy.value !== key
+    ? "none"
+    : sortDesc.value
+    ? "descending"
+    : "ascending";
+}
+
+// The pages are prerendered,
+// so the query string and the stored preferences are only available once we are
+// running in the browser.
+// Applying them after mount keeps the hydrated markup identical to the generated one.
+const route = useRoute();
+const router = useRouter();
+let ready = false;
+
+onMounted(() => {
+  const query = route.query;
+  const stored = readStored();
+
+  const cols = param(query.cols) ?? stored?.cols;
+  if (cols) {
+    const keys = cols.split(",").filter((key) => byKey.has(key));
+    if (keys.length) {
+      visible.value = columns.map((c) => c.key).filter((k) => keys.includes(k));
+    }
+  }
+
+  const sort = param(query.sort) ?? stored?.sort;
+  if (sort) {
+    const [key, direction] = sort.split(":");
+    if (byKey.has(key)) {
+      sortBy.value = key;
+      sortDesc.value = direction === "desc";
+    }
+  }
+
+  filters.value = Object.fromEntries(
+    Object.entries(query)
+      .filter(([key]) => key.startsWith("q_") && byKey.has(key.slice(2)))
+      .map(([key, value]) => [key.slice(2), param(value)])
+      .filter(([, value]) => value)
+  ) as Record<string, string>;
+
+  ready = true;
+});
+
+watch([visible, sortBy, sortDesc, filters], () => {
+  if (!ready) {
+    return;
+  }
+  const sort = sortBy.value
+    ? `${sortBy.value}:${sortDesc.value ? "desc" : "asc"}`
+    : undefined;
+  const cols = visible.value.join(",");
+
+  router.replace({
+    query: {
+      ...(cols === defaultColumns.join(",") ? {} : { cols }),
+      ...(sort ? { sort } : {}),
+      ...Object.fromEntries(
+        Object.entries(filters.value)
+          .filter(([, value]) => value)
+          .map(([key, value]) => [`q_${key}`, value])
+      ),
+    },
+  });
+
+  try {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ cols, ...(sort ? { sort } : {}) })
+    );
+  } catch {
+    // storage may be unavailable, the column setup is not worth failing over
+  }
+});
+
+function param(value: unknown): string | undefined {
+  const single = Array.isArray(value) ? value[0] : value;
+  return typeof single === "string" && single ? single : undefined;
+}
+
+function readStored(): { cols?: string; sort?: string } | null {
+  try {
+    return JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "null");
+  } catch {
+    return null;
+  }
+}
+</script>
+
+<style scoped>
+.columns {
+  margin: 1em 0;
+}
+.columns label {
+  display: inline-block;
+  margin-right: 1em;
+  white-space: nowrap;
+}
+.summary {
+  color: #555;
+  font-size: 0.9em;
+}
+th {
+  padding: 0;
+}
+button.sort {
+  width: 100%;
+  padding: 5px;
+  border: none;
+  background: none;
+  font: inherit;
+  font-weight: bold;
+  text-align: left;
+  cursor: pointer;
+}
+.indicator {
+  color: #555;
+}
+.filters td {
+  padding: 2px;
+}
+.filters input,
+.filters select {
+  width: 100%;
+  box-sizing: border-box;
+  font: inherit;
+}
+.numeric {
+  text-align: right;
+}
+.dates {
+  white-space: nowrap;
+}
+</style>

--- a/course-groups-resp.d.ts
+++ b/course-groups-resp.d.ts
@@ -1,0 +1,75 @@
+export type CourseGroupsResponse = {
+    readonly courseGroupDtos: CourseGroupDto[];
+    readonly links?:          Link[];
+    readonly totalCount?:     number;
+}
+
+export type CourseGroupDto = {
+    readonly id:                        number;
+    readonly name:                      string;
+    readonly courseId:                  number;
+    readonly appointmentDtos:           AppointmentDto[];
+    readonly appointmentSeriesDtos:     AppointmentSeriesDto[];
+    readonly standardgroupFlag:         Flag;
+    readonly confirmedPlaces?:          number;
+    readonly limitedParticipationFlag?: Flag;
+    readonly schilfFlag?:               Flag;
+}
+
+export type AppointmentDto = {
+    readonly id:                       number;
+    readonly weekday:                  WeekdayDto;
+    readonly timestampFrom:            DateTime;
+    readonly timestampTo:              DateTime;
+    readonly appointmentEventTypeDto:  AppointmentEventTypeDto;
+    readonly resourceId?:              number;
+    readonly resourceName?:            string;
+    readonly appointmentStatusType:    AppointmentStatusType;
+    readonly interGroupFlag?:          Flag;
+    readonly appointmentSeriesId?:     number;
+}
+
+export type AppointmentSeriesDto = {
+    readonly id:              number;
+    readonly seriesBeginTime: string;
+    readonly seriesEndTime:   string;
+    readonly seriesBegin:     DateTime;
+    readonly seriesEnd:       DateTime;
+    readonly resourceName?:   string;
+    readonly weekday:         WeekdayDto[];
+}
+
+export type WeekdayDto = {
+    readonly id:           number;
+    readonly key:          string;
+    readonly langDataType: LangData;
+}
+
+export type AppointmentEventTypeDto = {
+    readonly id:   number;
+    readonly name: LangData;
+    readonly key:  string;
+    readonly sort: number;
+}
+
+// `coType` is stripped from the cached course files to save space, hence optional
+export type LangData = {
+    readonly coType?: "model-core.lib.model.langdata";
+    readonly value:   string;
+}
+
+export type DateTime = {
+    readonly coType?: "datetime";
+    readonly value:   string;
+}
+
+export type AppointmentStatusType = "CONFIRMED" | "CANCELLED";
+
+export type Flag = "J" | "N";
+
+export type Link = {
+    readonly rel:   string;
+    readonly href:  string;
+    readonly name:  string;
+    readonly key?:  string;
+}

--- a/course-row.d.ts
+++ b/course-row.d.ts
@@ -1,0 +1,17 @@
+import type { AppointmentSummary } from "./appointments";
+
+/** One course of a curriculum leaf, flattened for the course table. */
+export type CourseRow = {
+  readonly key: string;
+  readonly module: string;
+  readonly iconName: string;
+  readonly courseType: string;
+  readonly title: string;
+  readonly credits: number | null;
+  readonly sws: string | null;
+  readonly semesterRecommendation: string | null;
+  readonly subjectType: string | null;
+  readonly examMethod: string | null;
+  readonly appointments: AppointmentSummary[];
+  readonly courseId: string;
+};

--- a/fetch-data.ts
+++ b/fetch-data.ts
@@ -7,6 +7,7 @@ import type { CoursesResponse } from "./courses-resp";
 import type { SemestersResponse } from "./semesters-resp";
 import type { CourseResponse } from "./course-resp";
 import type { CurriculumPositionsResponse } from "./curriculum-pos-resp";
+import type { CourseGroupsResponse } from "./course-groups-resp";
 
 const MAX_PAGE_SIZE = 100;
 const CONCURRENCY_LIMIT = 100;
@@ -89,6 +90,27 @@ async function main() {
   ).flat();
   console.log("#Requests (to fetch course data):", courses.length);
 
+  // Appointments live in a separate resource which only hands out the first five groups;
+  // the remainder has to be requested explicitly.
+  // Courses without any group (e.g. exams) simply have no dates here.
+  const fetchCourseGroups = async (courseId: number) => {
+    try {
+      const first = await client
+        .get(`slc.tm.cp/student/courseGroups/firstGroups/${courseId}`)
+        .json<CourseGroupsResponse>();
+      if ((first.totalCount ?? 0) <= first.courseGroupDtos.length) {
+        return first.courseGroupDtos;
+      }
+      const remaining = await client
+        .get(`slc.tm.cp/student/courseGroups/remainingGroups/${courseId}`)
+        .json<CourseGroupsResponse>();
+      return [...first.courseGroupDtos, ...remaining.courseGroupDtos];
+    } catch (e) {
+      console.error(`Could not fetch groups of course ${courseId}`, e);
+      return [];
+    }
+  };
+
   const fetchAndSave = async (courseId: number, storagePath: string) => {
     try {
       const resp = await client
@@ -107,6 +129,7 @@ async function main() {
             )
             .json<CurriculumPositionsResponse>()
         ).resource.map((res) => res.content),
+        courseGroups: await fetchCourseGroups(courseId),
       };
 
       // drop some keys we currently do not need to reduce file size
@@ -121,6 +144,11 @@ async function main() {
           "lectureships",
           "reference",
           "validFrom",
+          "resourceUrl",
+          "urlGroups",
+          "appointmentLectureshipDto",
+          "lectureshipDtos",
+          "courseGroupDto",
         ].includes(k)
           ? undefined
           : v;

--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     "dev": "nuxt dev",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
+    "data": "pnpm run data:fetch && pnpm run data:transform && pnpm run data:build-db",
+    "data:fetch": "node fetch-data.ts",
+    "data:transform": "node transform.ts",
+    "data:build-db": "node build-db.ts",
     "postinstall": "nuxt prepare"
   },
   "dependencies": {

--- a/pages/query.vue
+++ b/pages/query.vue
@@ -127,6 +127,10 @@ const examples = [
     sql: "SELECT s.designation AS semester, cu.displayed_type AS study_type,\n       cu.name AS study, n.name AS position, c.title, p.credits\nFROM course_placements p\nJOIN courses c  ON c.id = p.course_id\nJOIN curricula cu ON cu.curriculum_version_id = p.curriculum_version_id\nJOIN curriculum_nodes n\n     ON n.curriculum_version_id = p.curriculum_version_id\n    AND n.element_id = p.leaf_element_id\nJOIN semesters s ON s.id = c.semester_id\nORDER BY c.title\nLIMIT 100;",
   },
   {
+    label: "Monday mornings",
+    sql: "SELECT c.title, c.course_type_name, a.weekday, a.starts_at, a.ends_at,\n       a.room, a.occurrences\nFROM course_appointments a\nJOIN courses c ON c.id = a.course_id\nWHERE a.weekday_sort = 1 AND a.starts_at < '12:00'\nORDER BY a.starts_at, c.title\nLIMIT 100;",
+  },
+  {
     label: "Title search",
     sql: "SELECT id, semester_id, title, ects_credits\nFROM courses\nWHERE title LIKE '%Algebra%'\nORDER BY title;",
   },

--- a/pages/semesters/[term]/studies/[id]/courses/[...path].vue
+++ b/pages/semesters/[term]/studies/[id]/courses/[...path].vue
@@ -1,62 +1,60 @@
 <template>
   <h1>{{ data?.name }}</h1>
-  <table>
-    <thead>
-      <tr>
-        <th>Name</th>
-        <th>Course Type</th>
-        <th>Name</th>
-        <th>Credits</th>
-        <th>ID</th>
-      </tr>
-    </thead>
-    <template v-for="(value, key) in data?.children">
-      <tbody>
-        <template v-for="(value2, key2, idx) in value.children">
-          <tr v-for="(node, id, idx2) in value2.children">
-            <!--
-              The rowspan shenanigans are to fix one of:
-              - https://bugzilla.mozilla.org/show_bug.cgi?id=1000435
-              - https://bugzilla.mozilla.org/show_bug.cgi?id=217769
-              - https://bugzilla.mozilla.org/show_bug.cgi?id=244135
-              - https://bugzilla.mozilla.org/show_bug.cgi?id=332740
-              - https://bugzilla.mozilla.org/show_bug.cgi?id=332977
-            -->
-            <td
-              v-if="idx === 0 && idx2 === 0"
-              :rowspan="
-                Object.values(value.children)
-                  .map((v) => Object.values(v.children).length)
-                  .reduce((a, b) => a + b)
-              "
-            >
-              {{ value.name }}
-            </td>
-            <td>
-              (<i :class="`icon_${value2.iconName}`" />)
-              {{ node.courseTypeDto }}
-            </td>
-            <td>{{ node.name }}</td>
-            <td>{{ node.credits ?? "" }}</td>
-            <td>
-              <a
-                :href="`https://online.rwth-aachen.de/RWTHonline/ee/ui/ca2/app/desktop/#/slc.tm.cp/student/courses/${id}`"
-              >
-                {{ id }}
-              </a>
-            </td>
-          </tr>
-        </template>
-      </tbody>
-    </template>
-  </table>
+  <CourseTable :rows="rows" />
 </template>
 
 <script setup lang="ts">
+import type { CourseRow } from "~/course-row";
+import type { CourseNode, PathEntry } from "~/studies-tree";
+
+const LEAF_NODE = "stp_empty";
+const MODULE_NODE = "stp_3";
+
 const route = useRoute();
 const { data } = await useFetch(
   `/api/semesters/${route.params.term}/studies/${route.params.id}/courses/${(
     route.params.path as string[]
   ).join("/")}`
+);
+
+/**
+ * The depth below a curriculum node varies,
+ * so instead of nesting a fixed number of loops the tree is walked down to the courses.
+ * The module of a course is the closest module node above it,
+ * the direct parent supplies the icon telling apart lecture, exercise and the like.
+ */
+function flatten(
+  node: Pick<PathEntry, "children">,
+  ancestors: PathEntry[] = []
+): CourseRow[] {
+  return Object.entries(node.children ?? {}).flatMap(([id, child]) => {
+    if (child.iconName !== LEAF_NODE) {
+      return flatten(child, [...ancestors, child]);
+    }
+    const course = child as CourseNode;
+    return [
+      {
+        key: [...ancestors.map((a) => a.name), id].join("/"),
+        module:
+          ancestors.findLast((a) => a.iconName === MODULE_NODE)?.name ??
+          ancestors[0]?.name ??
+          "",
+        iconName: ancestors.at(-1)?.iconName ?? "",
+        courseType: course.courseType ?? "",
+        title: course.name,
+        credits: course.credits ?? null,
+        sws: course.sws ?? null,
+        semesterRecommendation: course.semesterRecommendation ?? null,
+        subjectType: course.subjectType ?? null,
+        examMethod: course.examMethod ?? null,
+        appointments: course.appointments ?? [],
+        courseId: id,
+      } satisfies CourseRow,
+    ];
+  });
+}
+
+const rows = computed(() =>
+  data.value ? flatten(data.value as PathEntry) : []
 );
 </script>

--- a/serialized-course.d.ts
+++ b/serialized-course.d.ts
@@ -1,6 +1,9 @@
+import type { CourseGroupDto } from "./course-groups-resp";
+
 export type SerializedCourse = {
     readonly courseDetail:        CourseDetail;
     readonly curriculumPositions: CurriculumPosition[];
+    readonly courseGroups:        CourseGroupDto[];
 }
 
 export type CourseDetail = {

--- a/server/api/semesters/[term]/studies/[id]/courses/[...path].ts
+++ b/server/api/semesters/[term]/studies/[id]/courses/[...path].ts
@@ -1,19 +1,45 @@
 import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
-import { StudiesTree } from "~/studies-tree";
+import type { CoursesInfo, PathEntry, StudiesTree } from "~/studies-tree";
+
+const LEAF_NODE = "stp_empty";
 
 const studyInfos: Record<string, StudiesTree> = {};
+const courseInfos: Record<string, CoursesInfo> = {};
+
+async function readCache<T>(term: string, file: string): Promise<T> {
+  return JSON.parse(
+    await readFile(path.join(homedir(), ".cache/campusoffline", term, file), {
+      encoding: "utf-8",
+    })
+  ) as T;
+}
+
+/**
+ * The tree only carries what differs per placement;
+ * everything shared by all placements of a course is stored once per semester
+ * and merged back in here.
+ */
+function withCourseInfo(node: PathEntry, courses: CoursesInfo): PathEntry {
+  return {
+    ...node,
+    children: Object.fromEntries(
+      Object.entries(node.children).map(([id, child]) => [
+        id,
+        child.iconName === LEAF_NODE
+          ? { ...courses[id], ...child }
+          : withCourseInfo(child, courses),
+      ])
+    ),
+  };
+}
 
 export default defineEventHandler(async (event) => {
   const term = getRouterParam(event, "term")!;
   if (!(term in studyInfos)) {
-    studyInfos[term] = JSON.parse(
-      await readFile(
-        path.join(homedir(), ".cache/campusoffline", term, "studiesTree.json"),
-        { encoding: "utf-8" }
-      )
-    ) as StudiesTree;
+    studyInfos[term] = await readCache<StudiesTree>(term, "studiesTree.json");
+    courseInfos[term] = await readCache<CoursesInfo>(term, "courses.json");
   }
   const data = studyInfos[term];
 
@@ -27,8 +53,9 @@ export default defineEventHandler(async (event) => {
 
   // TODO clean this up
   const [prefix, ...rest] = getRouterParam(event, "path")?.split("/")!;
-  return rest.reduce(
+  const node = rest.reduce(
     (obj, key) => obj["children"][key],
     data[id].currics[prefix]
   );
+  return withCourseInfo(node, courseInfos[term]!);
 });

--- a/studies-tree.d.ts
+++ b/studies-tree.d.ts
@@ -1,4 +1,16 @@
+import type { AppointmentSummary } from "./appointments";
+
 export type StudiesTree = { [key: string]: StudyInfo };
+
+/** Course attributes shared by all placements of a course within a semester. */
+export type CoursesInfo = { [courseId: string]: CourseInfo };
+
+export type CourseInfo = {
+  readonly courseType: string;
+  readonly sws?: string | undefined;
+  readonly examMethod?: string | undefined;
+  readonly appointments: AppointmentSummary[];
+};
 
 export type StudyInfo = {
   readonly studyNameInfo: StudyNameInfo;
@@ -9,9 +21,13 @@ export type PathEntry = {
   readonly name: string;
   readonly iconName: string;
   readonly credits?: number | undefined;
-  readonly courseTypeDto?: string;
+  readonly subjectType?: string | undefined;
+  readonly semesterRecommendation?: string | undefined;
   readonly children: { [key: string]: PathEntry };
 };
+
+/** A curriculum leaf with the shared course attributes merged in. */
+export type CourseNode = PathEntry & Partial<CourseInfo>;
 
 export type StudyNameInfo = {
   readonly curriculumVersionId: number;

--- a/transform.ts
+++ b/transform.ts
@@ -6,7 +6,7 @@ import groupBy from "object.groupby";
 import { glob } from "glob";
 import type { SerializedCourse } from "./serialized-course";
 import type { CourseInfo, StudiesTree } from "./studies-tree";
-import { summarizeAppointments } from "./appointments";
+import { summarizeAppointments } from "./appointments.ts";
 
 type TreeNode = {
   name: string;

--- a/transform.ts
+++ b/transform.ts
@@ -5,7 +5,8 @@ import pMap, { pMapIterable } from "p-map";
 import groupBy from "object.groupby";
 import { glob } from "glob";
 import type { SerializedCourse } from "./serialized-course";
-import type { StudiesTree } from "./studies-tree";
+import type { CourseInfo, StudiesTree } from "./studies-tree";
+import { summarizeAppointments } from "./appointments";
 
 type TreeNode = {
   name: string;
@@ -13,12 +14,14 @@ type TreeNode = {
   children: Record<number, TreeNode>;
 
   credits?: number;
-  courseTypeDto?: string;
+  subjectType?: string;
+  semesterRecommendation?: string;
 };
 
 async function transformDir(dir: string) {
   const courseFiles = (
-    await glob("course*.json", {
+    // course<id>.json, i.e. everything but the derived courses.json
+    await glob("course[0-9]*.json", {
       withFileTypes: true,
       cwd: dir,
     })
@@ -28,6 +31,7 @@ async function transformDir(dir: string) {
   let progress = 0;
 
   const studies = [];
+  const courses: Record<number, CourseInfo> = {};
 
   for await (const studyInfos of await pMapIterable(
     courseFiles,
@@ -38,6 +42,19 @@ async function transformDir(dir: string) {
     },
     { concurrency: 10 }
   )) {
+    const course = studyInfos.courseDetail.cpCourseDto;
+    courses[course.id] = {
+      courseType: course.courseTypeDto.courseTypeName.value,
+      // SST is the course norm config carrying the SWS ("Semesterwochenstunden")
+      sws: course.courseNormConfigs?.find((c) => c.key === "SST")?.value,
+      // RWTHonline uses "---" where no examination method is set
+      examMethod:
+        course.examinationMethodName?.value === "---"
+          ? undefined
+          : course.examinationMethodName?.value,
+      appointments: summarizeAppointments(studyInfos.courseGroups ?? []),
+    };
+
     for (const {
       coCurriculumPositionDto: studyInfo,
     } of studyInfos.curriculumPositions) {
@@ -58,12 +75,13 @@ async function transformDir(dir: string) {
             credits:
               studyInfo.creditsDto?.value ??
               studyInfos.courseDetail.cpCourseDto.ectsCredits,
-            courseTypeDto:
-              studyInfos.courseDetail.cpCourseDto.courseTypeDto.courseTypeName
-                .value,
+            subjectType: studyInfo.subjectTypeDto?.value?.value,
+            semesterRecommendation:
+              studyInfo.semesterRecommendationDto?.keyWinterstarter,
           } satisfies (typeof studyInfo.curriculumPositionPathDto.path)[number] & {
             credits: number | undefined;
-            courseTypeDto: string;
+            subjectType: string | undefined;
+            semesterRecommendation: string | undefined;
           },
         ],
       });
@@ -98,7 +116,9 @@ async function transformDir(dir: string) {
             };
             if ("credits" in entry) {
               node.children[elementId].credits = entry.credits;
-              node.children[elementId].courseTypeDto = entry.courseTypeDto;
+              node.children[elementId].subjectType = entry.subjectType;
+              node.children[elementId].semesterRecommendation =
+                entry.semesterRecommendation;
             }
           }
           node = node.children[elementId];
@@ -124,6 +144,11 @@ async function transformDir(dir: string) {
     path.join(dir, "studiesTree.json"),
     JSON.stringify(studiesTree, null, 2)
   );
+
+  // Every course sits in a handful of curriculum positions,
+  // so the attributes shared by all of them live in their own file
+  // instead of being repeated for each placement in the tree.
+  await fs.writeFile(path.join(dir, "courses.json"), JSON.stringify(courses));
 }
 
 async function main() {


### PR DESCRIPTION
## Summary
This PR introduces a comprehensive course table component that replaces the static course listing on the curriculum page. The new table provides interactive features for exploring courses including sorting, filtering, column visibility management, and persistent configuration via URL and localStorage.

## Key Changes

- **New CourseTable component** (`components/CourseTable.vue`): A fully-featured data table with:
  - Column visibility toggling with a collapsible menu
  - Multi-column sorting (ascending/descending)
  - Text search and select-based filtering
  - Persistent configuration stored in URL query parameters and localStorage
  - Grouped rows by module with proper rowspan handling
  - Accessible markup with ARIA sort attributes

- **Course data model** (`course-row.d.ts`): New `CourseRow` type that flattens the curriculum tree into a tabular format with all course attributes needed for display and filtering

- **Appointment handling** (`appointments.ts`): New module that:
  - Summarizes individual course appointments into recurring time slots
  - Filters out cancelled dates
  - Formats appointments for display with weekday, time, room, and occurrence count
  - Supports multi-group courses

- **Data pipeline updates**:
  - `fetch-data.ts`: Added fetching of course groups and appointments from RWTHonline API
  - `transform.ts`: Extracts course metadata (SWS, exam method, appointments) and builds a separate courses index
  - `build-db.ts`: New database tables for `course_groups` and `course_appointments` with appropriate indexes
  - `studies-tree.d.ts`: New `CourseInfo` and `CoursesInfo` types for shared course attributes

- **API endpoint enhancement** (`server/api/semesters/[term]/studies/[id]/courses/[...path].ts`): Merges course metadata back into the curriculum tree structure for the frontend

- **Page refactor** (`pages/semesters/[term]/studies/[id]/courses/[...path].vue`): Replaces nested template loops with a single `CourseTable` component, using a new `flatten()` function to convert the tree structure into rows

- **Documentation**: Updated README with description of the configurable course table feature

## Notable Implementation Details

- The curriculum tree depth varies, so tree traversal walks down to leaf nodes rather than using fixed nesting levels
- Course metadata is stored separately per semester to avoid duplication across multiple curriculum placements
- Column configuration is preserved in the URL for shareability and survives page reloads via localStorage fallback
- Sorting uses custom sort keys for numeric fields (credits, SWS) to handle null/missing values correctly
- Module grouping is maintained in the rendered table with rowspan to preserve visual hierarchy

https://claude.ai/code/session_01T9RsMWtwGThbGbPVP7hP3f